### PR TITLE
Separate agentset and list primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,182 @@
-# NetLogo Rnd Extension
+# NetLogo `rnd` Extension
 
-This extension adds the [`rnd:weighted-one-of`](#rndweighted-one-of--agentset-reporter-task), [`rnd:weighted-n-of`](#rndweighted-n-of-size-agentset-reporter-task) and [`rnd:weighted-n-of-with-repeats`](#rndweighted-n-of-with-repeats-size-agentset-reporter-task) primitives to NetLogo.
+This extension adds the ability to do [roulette wheel selection](https://en.wikipedia.org/wiki/Fitness_proportionate_selection) in NetLogo. It provides a simpler way to accomplish the same thing as the [Lottery Example](https://github.com/NetLogo/models/blob/master/Code%20Examples/Lottery%20Example.nlogo) from the NetLogo Models Library.
 
-You can [download the Rnd extension from here](https://github.com/NetLogo/Rnd-Extension/releases). Just unzip the file under your NetLogo's extensions folder.
+You can [download the `rnd` extension from here](https://github.com/NetLogo/Rnd-Extension/releases). Just unzip the file under NetLogo's `extensions/` folder.
 
 ## Usage
 
-#### `rnd:weighted-one-of`  _agentset_ _reporter-task_
-#### `rnd:weighted-one-of`  _list_ _reporter-task_
+Which primitive to use depends on whether you want to select an item from a list or from an agenset. It also depends on whether you want one or many items and, if you want many, if repeats are allowed or not. The following table summarizes the situation:
 
-From an agentset, reports a random agent. If the agentset is empty, reports [`nobody`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#nobody).
+| | From an AgentSet | From a List |
+|---|---|---|
+| One item | [`rnd:weighted-one-of`](#rndweighted-one-of-agentset--reporter-) | [`rnd:weighted-one-of-list`](#rndweighted-one-of-list-list-reporter-task) |
+| Many items, without repeats | [`rnd:weighted-n-of`](#rndweighted-n-of-size-agentset--reporter-) | [`rnd:weighted-n-of-list`](#rndweighted-n-of-list-size-list-reporter-task) |
+| Many items, with repeats | [`rnd:weighted-n-of-with-repeats`](#rndweighted-n-of-with-repeats-size-agentset--reporter-) | [`rnd:weighted-n-of-list-with-repeats`](#rndweighted-n-of-list-with-repeats-size-list-reporter-task) |
 
-From a list, reports a random list item. It is an error for the list to be empty.
+(**Note:** the initial version of the extension had a single set of primitives for both lists and agentsets, but it turned out to be confusing, so we changed it. If you were using the old version of the extension, you will need to modify your code to use the new primitives.)
 
-In both cases, the probability of each item being picked is proportional to the weight reported by _reporter-task_ for this item. The input to the reporter task (i.e., `?`) is the item itself. A common way to use the primitive is to have a list of lists, where the first item of each sublist is the thing you want to choose and the second item is the weight. Here is a short example:
+In all cases, you will need to provide two things to the primitive:
+
+- The "candidates": the items that the primitive will select from.
+- The "weight": how likely it is for each candidate to be selected.
+
+If you want to select more than one items, you will also need to tell it:
+
+- How many items to select.
+
+## AgentSet Primitives
+
+#### <tt>rnd:weighted-one-of <i>agentset</i> [ <i>reporter</i> ]</tt>
+
+Reports a random agent from <tt><i>agentset</i></tt>.
+
+The probability of each agent being picked is proportional to the weight given by the <tt><i>reporter</i></tt> for that agent. The weights must not be negative.
+
+If the agentset is empty, it reports [`nobody`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#nobody).
+
+Here is a full rewrite of the **Lottery Example** model using the `rnd:weighted-one-of` primitive:
 
 ```
-let probs [ [ "A" 0.2 ] [ "B" 0.8 ] ]
-print n-values 10 [ first rnd:weighted-one-of probs [ last ? ] ]
+extensions [ rnd ]
+
+to setup
+  clear-all
+  ; create a turtle on every fifth patch
+  ask patches with [ pxcor mod 5 = 0 and pycor mod 5 = 0 ] [
+    sprout 1 [
+      set size 2 + random 6 ; vary the size of the turtles
+      set label 0           ; start them out with no wins
+      set color color - 2   ; make turtles darker so the labels stand out
+    ]
+  ]
+  reset-ticks
+end
+
+to go
+  ask rnd:weighted-one-of turtles [ size ] [
+    set label label + 1
+  ]
+  tick
+end
 ```
-
-This should print a list of ten letters with roughly four Bs for an A.
-
-The weights reported by _reporter-task_ must not be negative.
-
-If all weights are `0.0`, each candidate has an equal probability of being picked.
-
-When used with an agentset, you need to use the same syntax as when you use lists. That is, you _cannot_ write:
-
-    rnd:weighted-one-of turtles [ size ] ; will NOT work!
-
-You need to write:
-
-    rnd:weighted-one-of turtles [ [ size ] of ? ]
-
-This is admittedly confusing and we would like to [fix it eventually](https://github.com/NetLogo/Rnd-Extension/issues/5).
 
 ***
 
-#### `rnd:weighted-n-of` _size_ _agentset_ _reporter-task_
-#### `rnd:weighted-n-of` _size_ _list_ _reporter-task_
+#### <tt>rnd:weighted-n-of <i>size</i> <i>agentset</i> [ <i>reporter</i> ]</tt>
 
-From an agentset, reports an agentset of size _size_ randomly chosen from the input set, with no repeats.
+Reports an agentset of the given <tt><i>size</i></tt> randomly chosen from the <tt><i>agentset</i></tt>, with no repeats.
 
-From a list, reports a list of size _size_ randomly chosen from the input set, with **no repeats**. The items in the result appear in the same order that they appeared in the input list. (If you want them in random order, use shuffle on the result.)
+The probability of each agent being picked is proportional to the weight given by the <tt><i>reporter</i></tt> for that agent. The weights must be non-negative numbers.
 
-In both cases, the probability of each item being picked is proportional to the weight reported by _reporter-task_ for this item.
-
-It is an error for _size_ to be greater than the size of the input.
-
-The weights reported by _reporter-task_ must not be negative.
-
-Note that you need to use the same reporter task syntax (i.e., with `?`) with both lists and agentsets. See [`rnd:weighted-one-of`](#rndweighted-one-of--agentset-reporter-task) for an example.
+It is an error for <tt><i>size</i></tt> to be greater than the size of the <tt><i>agentset</i></tt>.
 
 If, at some point during the selection, there remains only candidates with a weight of `0.0`, they all have an equal probability of getting picked.
 
-[This stackoverflow answer](http://stackoverflow.com/a/25165327/487946) shows an example of using `rnd:weighted-n-of` to simulate a normally distributed version of [`n-of`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#n-of).
-
 ***
 
-#### `rnd:weighted-n-of-with-repeats` _size_ _agentset_ _reporter-task_
-#### `rnd:weighted-n-of-with-repeats` _size_ _list_ _reporter-task_
+#### <tt>rnd:weighted-n-of-with-repeats <i>size</i> <i>agentset</i> [ <i>reporter</i> ]</tt>
 
-From either an agent or a list, reports a **list** of size _size_ randomly chosen from the input set, **with repeats**. The items in the result appear in the same order that they appeared in the input list. (If you want them in random order, use shuffle on the result.)
+Reports a **list** of the given <tt><i>size</i></tt> randomly chosen from the <tt><i>agentset</i></tt>, with repeats. (Why a list instead of an agentset? Because an agentset cannot contain the same agent more than once.)
 
-The probability of each item being picked is proportional to the weight reported by _reporter-task_ for this item.
+The probability of each agent being picked is proportional to the weight given by the <tt><i>reporter</i></tt> for that agent. The weights must be non-negative numbers.
 
-It is **not** an error for _size_ to be greater than the size of the input, but there has to be at least one candidate.
+It is **not** an error for <tt><i>size</i></tt> to be greater than the size of the <tt><i>agentset</i></tt>, but there has to be at least one candidate.
 
-The weights reported by _reporter-task_ must not be negative.
+If, at some point during the selection, there remains only candidates with a weight of `0.0`, they all have an equal probability of getting picked.
 
 If all weights are `0.0`, each candidate has an equal probability of being picked.
 
-Note that you need to use the same reporter task syntax (i.e., with `?`) with both lists and agentsets. See [`rnd:weighted-one-of`](#rndweighted-one-of--agentset-reporter-task) for an example.
+## List primitives
 
-### A note about performance
+#### <tt>rnd:weighted-one-of-list <i>list</i> <i>reporter-task</i></tt>
+
+Reports a random item from <tt><i>list</i></tt>.
+
+The probability of each item being picked is proportional to the weight given by the <tt><i>reporter-task</i></tt> for that item. The weights must not be negative. In the reporter task, you can refer to the list item by using the [`?`](https://ccl.northwestern.edu/netlogo/docs/dictionary.html#ques) character. See the [Tasks section](https://ccl.northwestern.edu/netlogo/docs/programming.html#tasks) of the Programming Guide for more details.)
+
+It is an error for the list to be empty.
+
+A common way to use the primitive is to have a list of lists, where the first item of each sublist is the thing you want to choose and the second item is the weight. Here is a short example:
+
+```
+let probs [ [ "A" 0.2 ] [ "B" 0.8 ] ]
+repeat 25 [
+  ; report the first item of the pair selected using
+  ; the second item (i.e., `last ?`) as the weight
+  type first rnd:weighted-one-of-list probs [ last ? ]
+]
+```
+
+This should print `B` roughly four times more often than it prints `A`.
+
+***
+
+#### <tt>rnd:weighted-n-of-list <i>size</i> <i>list</i> <i>reporter-task</i></tt>
+
+Reports a list of the given <tt><i>size</i></tt> randomly chosen from the <tt><i>list</i></tt> of candidates, with no repeats.
+
+The probability of each item being picked is proportional to the weight given by the <tt><i>reporter-task</i></tt> for that item. The weights must not be negative. In the reporter task, you can refer to the list item by using the [`?`](https://ccl.northwestern.edu/netlogo/docs/dictionary.html#ques) character. See the [Tasks section](https://ccl.northwestern.edu/netlogo/docs/programming.html#tasks) of the Programming Guide for more details.)
+
+It is an error for <tt><i>size</i></tt> to be greater than the size of the <tt><i>list</i> of candidates</tt>.
+
+If, at some point during the selection, there remains only candidates with a weight of `0.0`, they all have an equal probability of getting picked.
+
+The items in the resulting list appear in the same order that they appeared in the list of candidates. (If you want them in random order, use [`shuffle`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#shuffle) on the result).
+
+Example:
+```
+let candidates n-values 8 [ 2 ^ (? + 1) ] ; make a list with the powers of two
+print rnd:weighted-n-of-list 4 candidates [ ? ]
+```
+
+This should print a list of four numbers, where the bigger numbers (32, 64, 128, 256) have a much better chance to show up than the smaller ones (2, 4, 8, 16).
+
+***
+
+#### <tt>rnd:weighted-n-of-list-with-repeats <i>size</i> <i>list</i> <i>reporter-task</i></tt>
+
+Reports a list of the given <tt><i>size</i></tt> randomly chosen from the <tt><i>list</i></tt> of candidates, with repeats.
+
+The probability of each item being picked is proportional to the weight given by the <tt><i>reporter-task</i></tt> for that item. The weights must not be negative. In the reporter task, you can refer to the list item by using the [`?`](https://ccl.northwestern.edu/netlogo/docs/dictionary.html#ques) character. See the [Tasks section](https://ccl.northwestern.edu/netlogo/docs/programming.html#tasks) of the Programming Guide for more details.)
+
+It is **not** an error for <tt><i>size</i></tt> to be greater than the size of the <tt><i>list</i></tt> of candidates, but there has to be at least one candidate.
+
+If, at some point during the selection, there remains only candidates with a weight of `0.0`, they all have an equal probability of getting picked.
+
+If all weights are `0.0`, each candidate has an equal probability of being picked.
+
+The items in the resulting list appear in the same order that they appeared in the list of candidates. (If you want them in random order, use [`shuffle`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#shuffle) on the result).
+
+Example:
+```
+let probs [ [ "A" 0.2 ] [ "B" 0.8 ] ]
+print map first rnd:weighted-n-of-list-with-repeats 25 probs [ last ? ]
+```
+
+This should print a list of 25 `A`s and `B`s, with roughly four times as many `B`s than `A`s.
+
+## A note about performance
 
 The extension uses Keith Schwarz's implementation of Vose's Alias Method (see Schwarz's [Darts, Dice, and Coins](http://www.keithschwarz.com/darts-dice-coins/) page). Assuming you are choosing _n_ candidates for a collection of size _m_ **with repeats**, this method has an initialization cost of _O(m)_ followed by a cost of _O(1)_ for each item you pick, so _O(m + n)_ overall.
 
 For example, in the following code:
 
     let candidates n-values 500 [ ? ]
-    rnd:weighted-n-of-with-repeats 100 candidates [ ? ]
-    n-values 100 [ rnd:weighted-one-of candidates [ ? ] ]
+    rnd:weighted-n-of-list-with-repeats 100 candidates [ ? ]
+    n-values 100 [ rnd:weighted-one-of-list candidates [ ? ] ]
 
-...the line using `rnd:weighted-n-of-with-repeats` will likely run 100 times faster than the line using a combination of `n-values` and `rnd:weighted-one-of`. This is because `rnd:weighted-n-of-with-repeats` only initializes the algorithm once and `rnd:weighted-one-of` does it each time it is called.
+...the line using `rnd:weighted-n-of-list-with-repeats` will likely run 100 times faster than the line using a combination of `n-values` and `rnd:weighted-one-of-list`. This is because `rnd:weighted-n-of-list-with-repeats` only initializes the algorithm once and `rnd:weighted-one-of` does it each time it is called.
 
-(Also note that composing `n-values` with `rnd:weighted-one-of` does not preserve the order of the original candidate list, while `rnd:weighted-n-of-with-repeats` does.)
+(Note that composing `n-values` with `rnd:weighted-one-of-list` does not preserve the order of the original candidate list, while `rnd:weighted-n-of-list-with-repeats` does.)
 
 Things are a bit more complicated if you are choosing **without repeats**, however. In this case, the algorithm may have to discard some picks because the candidates have already been selected. When this starts happening too often (maybe because some weights are much bigger than others), the extension re-initializes the algorithm with the already-picked candidates excluded. This should not happen too often, however, so while picking without repeats has an upper bound of _O(m * n)_ in theory, it should usually not be much more than _O(m + n)_ in practice.
 
+The previous remarks apply to agentset primitives as much as they apply to list primitives.
+
 ## Building
 
-Run `./sbt package` to build the extension.
-
-If the build succeeds, `rnd.jar` will be created.
+If you want to build the extension from the source, it should be sufficient to run `./sbt package` from the extension's source directory. If the build succeeds, `rnd.jar` will be created.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -100,15 +100,25 @@ It is an error for the list to be empty.
 A common way to use the primitive is to have a list of lists, where the first item of each sublist is the thing you want to choose and the second item is the weight. Here is a short example:
 
 ```
-let probs [ [ "A" 0.2 ] [ "B" 0.8 ] ]
+let pairs [ [ "A" 0.2 ] [ "B" 0.8 ] ]
 repeat 25 [
   ; report the first item of the pair selected using
   ; the second item (i.e., `last ?`) as the weight
-  type first rnd:weighted-one-of-list probs [ last ? ]
+  type first rnd:weighted-one-of-list pairs [ last ? ]
 ]
 ```
 
 This should print `B` roughly four times more often than it prints `A`.
+
+If you happen to have your items and your weights in two separate lists, you can combine them into pairs by using a combination of [`map`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#map) and [`list`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#list):
+
+```
+let items [ "A" "B" "C" ]
+let weights [ 0.1 0.2 0.7 ]
+let pairs (map list items weights)
+```
+
+Since we apply [`map`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#map) to both the `items` list and the `weights` list, the parentheses are needed in `(map list items weights)`. We also use the concise task syntax (see the [programming guide](http://ccl.northwestern.edu/netlogo/docs/programming.html#Tasks)) to pass [`list`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#list) as the reporter task for [`map`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#map). The same thing could have been written `(map [ list ?1 ?2 ] items weights)`.
 
 ***
 
@@ -150,8 +160,8 @@ The items in the resulting list appear in the same order that they appeared in t
 
 Example:
 ```
-let probs [ [ "A" 0.2 ] [ "B" 0.8 ] ]
-print map first rnd:weighted-n-of-list-with-repeats 25 probs [ last ? ]
+let pairs [ [ "A" 0.2 ] [ "B" 0.8 ] ]
+print map first rnd:weighted-n-of-list-with-repeats 25 pairs [ last ? ]
 ```
 
 This should print a list of 25 `A`s and `B`s, with roughly four times as many `B`s than `A`s.

--- a/src/main/scala/org/nlogo/extensions/rnd/Primitives.scala
+++ b/src/main/scala/org/nlogo/extensions/rnd/Primitives.scala
@@ -20,52 +20,83 @@ import org.nlogo.util.MersenneTwisterFast
 trait WeightedRndPrim extends DefaultReporter {
   val name: String
 
+  def candidateVector(arg: Argument, rng: MersenneTwisterFast): Vector[AnyRef]
+
+  def candidateSyntaxType: Int
+  def reporterSyntaxType: Int
+  def inputSyntax: Array[Int]
+  def outputSyntax: Int
+  override def getSyntax = reporterSyntax(inputSyntax, outputSyntax)
+
   def getCandidates(minSize: Int, arg: Argument, rng: MersenneTwisterFast): Vector[AnyRef] = {
-    val candidates =
-      arg.get match {
-        case list: LogoList ⇒ list.toVector
-        case agentSet: agent.AgentSet ⇒
-          val b = Vector.newBuilder[AnyRef]
-          val it = agentSet.shufflerator(rng)
-          while (it.hasNext) b += it.next
-          b.result
-      }
+    val candidates = candidateVector(arg, rng)
+    def pluralize(count: Int, word: String) =
+      count + " " + word + (if (count != 1) "s" else "")
     if (candidates.size < minSize) throw new ExtensionException(
       "Requested " + pluralize(minSize, "random item") +
         " from " + pluralize(candidates.size, "candidate") + ".")
     candidates
   }
 
-  def getWeightFunction(arg: Argument, context: Context): (AnyRef) ⇒ Double = {
-    val task = arg.getReporterTask.asInstanceOf[nvm.ReporterTask]
-    if (task.formals.size > 1) throw new ExtensionException(
-      "Task expected only 1 input but got " + task.formals.size + ".")
-    (obj: AnyRef) ⇒ {
-      val res = task.report(context, Array(obj))
-      val w = try
-        res.asInstanceOf[Number].doubleValue
-      catch {
-        case e: ClassCastException ⇒ throw new ExtensionException(
-          "Got " + Dump.logoObject(res) + " as a weight but all weights must be numbers.")
-      }
-      if (w < 0.0) throw new ExtensionException(
-        "Got " + w + " as a weight but all weights must be >= 0.0.")
-      w
+  def reporterFunction(arg: Argument, context: Context): AnyRef => AnyRef
+
+  def getWeightFunction(arg: Argument, context: Context): AnyRef ⇒ Double =
+    (obj: AnyRef) ⇒ reporterFunction(arg, context)(obj) match {
+      case n: Number if n.doubleValue < 0.0 =>
+        throw new ExtensionException("Got " + n + " as a weight but all weights must be >= 0.0.")
+      case n: Number =>
+        n.doubleValue
+      case x =>
+        throw new ExtensionException("Got " + Dump.logoObject(x) + " as a weight but all weights must be numbers.")
+    }
+
+}
+
+trait AgentSetPrim {
+
+  self: DefaultReporter =>
+  override def getAgentClassString = "OT:-TPL"
+
+  def candidateSyntaxType: Int = AgentsetType
+  def reporterSyntaxType: Int = NumberBlockType
+
+  def candidateVector(arg: Argument, rng: MersenneTwisterFast): Vector[AnyRef] = {
+    val it = arg.getAgentSet.asInstanceOf[agent.AgentSet].shufflerator(rng)
+    val b = Vector.newBuilder[AnyRef]
+    while (it.hasNext) b += it.next
+    b.result
+  }
+
+  def reporterFunction(arg: Argument, context: Context): AnyRef => AnyRef = {
+    val nvmContext = context.asInstanceOf[nvm.ExtensionContext].nvmContext
+    val reporter = arg.asInstanceOf[nvm.Argument].getReporter
+    (obj: AnyRef) => {
+      val a = obj.asInstanceOf[agent.Agent]
+      new nvm.Context(nvmContext, a).evaluateReporter(a, reporter)
     }
   }
 
-  def pluralize(count: Int, word: String) =
-    count + " " + word + (if (count != 1) "s" else "")
 }
 
-object WeightedOneOfPrim extends WeightedRndPrim {
+trait ListPrim {
 
-  override val name = "WEIGHTED-ONE-OF"
+  def candidateSyntaxType: Int = ListType
+  def reporterSyntaxType: Int = ReporterTaskType
 
-  override def getSyntax = reporterSyntax(
-    Array(ListType | AgentsetType, ReporterTaskType),
-    WildcardType)
+  def candidateVector(arg: Argument, rng: MersenneTwisterFast): Vector[AnyRef] =
+    arg.getList.toVector
 
+  def reporterFunction(arg: Argument, context: Context): AnyRef => AnyRef = {
+    val task = arg.getReporterTask.asInstanceOf[nvm.ReporterTask]
+    if (task.formals.size > 1) throw new ExtensionException(
+      "Task expected only 1 input but got " + task.formals.size + ".")
+    (obj: AnyRef) ⇒ task.report(context, Array(obj))
+  }
+
+}
+
+trait WeightedOneOf extends WeightedRndPrim {
+  def inputSyntax = Array(candidateSyntaxType, reporterSyntaxType)
   def report(args: Array[Argument], context: Context): AnyRef =
     args(0).get match {
       case agentSet: agent.AgentSet if agentSet.count == 0 ⇒
@@ -79,67 +110,78 @@ object WeightedOneOfPrim extends WeightedRndPrim {
     }
 }
 
-trait WeightedNOfPrim extends WeightedRndPrim {
+object WeightedOneOfAgentSet extends WeightedOneOf with AgentSetPrim {
+  val name = "WEIGHTED-ONE-OF"
+  val outputSyntax = AgentType
+}
 
-  def pickIndices(n: Int,
-    candidates: Vector[AnyRef],
-    weightFunction: (AnyRef) ⇒ Double,
-    rng: MersenneTwisterFast): Iterable[Int]
+object WeightedOneOfList extends WeightedOneOf with ListPrim {
+  val name = "WEIGHTED-ONE-OF-LIST"
+  val outputSyntax = WildcardType
+}
 
-  val allowRepeats: Boolean
+trait WeightedNOf extends WeightedRndPrim {
+
+  def inputSyntax = Array(NumberType, candidateSyntaxType, reporterSyntaxType)
+
+  val pickIndices: (Int, Vector[AnyRef], AnyRef => Double, MersenneTwisterFast) => Iterable[Int]
+  def minSize(n: Int): Int
+
+  def outputBuilder(candidatesArg: Argument, candidates: Vector[AnyRef], indices: Iterable[Int]): AnyRef
 
   def report(args: Array[Argument], context: Context): AnyRef = {
     val n = args(0).getIntValue
     if (n < 0) throw new ExtensionException(I18N.errors.getN(
       "org.nlogo.prim.etc.$common.firstInputCantBeNegative", name))
     val rng = context.getRNG
-    val minSize = if (allowRepeats) math.min(n, 1) else n
-    val candidates: Vector[AnyRef] = getCandidates(minSize, args(1), rng)
+    val candidates: Vector[AnyRef] = getCandidates(minSize(n), args(1), rng)
     val weightFunction = getWeightFunction(args(2), context)
     val indices = pickIndices(n, candidates, weightFunction, rng)
-
-    def buildList: LogoList = {
-      val b = new LogoListBuilder
-      for (i ← indices) b.add(candidates(i))
-      b.toLogoList
-    }
-
-    def buildAgentSet(originalAgentSet: agent.AgentSet): agent.ArrayAgentSet = {
-      val b = Array.newBuilder[agent.Agent]
-      for (i ← indices) b += candidates(i).asInstanceOf[agent.Agent]
-      new agent.ArrayAgentSet(originalAgentSet.`type`, b.result, originalAgentSet.world)
-    }
-
-    args(1).get match {
-      case _: LogoList                       ⇒ buildList
-      case _: agent.AgentSet if allowRepeats ⇒ buildList
-      case agentSet: agent.AgentSet          ⇒ buildAgentSet(agentSet)
-    }
+    outputBuilder(args(1), candidates, indices)
   }
 }
 
-object WeightedNOfWithoutRepeatsPrim extends WeightedNOfPrim {
-  override val name = "WEIGHTED-N-OF"
-  override val allowRepeats = false
-  override def getSyntax = reporterSyntax(
-    Array(NumberType, ListType | AgentsetType, ReporterTaskType),
-    ListType | AgentsetType) // returns either list or agentset depending on args(1)
-  override def pickIndices(n: Int,
-    candidates: Vector[AnyRef],
-    weightFunction: (AnyRef) ⇒ Double,
-    rng: MersenneTwisterFast): SortedSet[Int] =
-    Picker.pickIndicesWithoutRepeats(n, candidates, weightFunction, rng)
+trait ListBuilder {
+  val outputSyntax = ListType
+  def outputBuilder(candidatesArg: Argument, candidates: Vector[AnyRef], indices: Iterable[Int]) = {
+    val b = new LogoListBuilder
+    for (i ← indices) b.add(candidates(i))
+    b.toLogoList
+  }
 }
 
-object WeightedNOfWithRepeatsPrim extends WeightedNOfPrim {
-  override val name = "WEIGHTED-N-OF-WITH-REPEATS"
-  override val allowRepeats = true
-  override def getSyntax = reporterSyntax(
-    Array(NumberType, ListType | AgentsetType, ReporterTaskType),
-    ListType) // always returns a list because agentsets don't allow repeats
-  override def pickIndices(n: Int,
-    candidates: Vector[AnyRef],
-    weightFunction: (AnyRef) ⇒ Double,
-    rng: MersenneTwisterFast): Seq[Int] =
-    Picker.pickIndicesWithRepeats(n, candidates, weightFunction, rng)
+trait AgentSetBuilder {
+  val outputSyntax = AgentsetType
+  def outputBuilder(candidatesArg: Argument, candidates: Vector[AnyRef], indices: Iterable[Int]) = {
+    val originalAgentSet = candidatesArg.get.asInstanceOf[agent.AgentSet]
+    val b = Array.newBuilder[agent.Agent]
+    for (i ← indices) b += candidates(i).asInstanceOf[agent.Agent]
+    new agent.ArrayAgentSet(originalAgentSet.`type`, b.result, originalAgentSet.world)
+  }
+}
+
+trait WithRepeats extends WeightedNOf with ListBuilder {
+  val pickIndices = Picker.pickIndicesWithRepeats _
+  def minSize(n: Int) = math.min(n, 1)
+}
+
+trait WithoutRepeats extends WeightedNOf {
+  val pickIndices = Picker.pickIndicesWithoutRepeats _
+  def minSize(n: Int) = n
+}
+
+object WeightedNOfAgentSetWithRepeats extends WithRepeats with AgentSetPrim {
+  val name = "WEIGHTED-N-OF-WITH-REPEATS"
+}
+
+object WeightedNOfListWithRepeats extends WithRepeats with ListPrim {
+  val name = "WEIGHTED-N-OF-LIST-WITH-REPEATS"
+}
+
+object WeightedNOfAgentSetWithoutRepeats extends WithoutRepeats with AgentSetPrim with AgentSetBuilder {
+  val name = "WEIGHTED-N-OF"
+}
+
+object WeightedNOfListWithoutRepeats extends WithoutRepeats with ListPrim with ListBuilder {
+  val name = "WEIGHTED-N-OF-LIST"
 }

--- a/src/main/scala/org/nlogo/extensions/rnd/RndExtension.scala
+++ b/src/main/scala/org/nlogo/extensions/rnd/RndExtension.scala
@@ -9,9 +9,12 @@ class RndExtension extends DefaultClassManager {
   override def load(primManager: PrimitiveManager) {
     for {
       prim ← Seq(
-        WeightedNOfWithRepeatsPrim,
-        WeightedNOfWithoutRepeatsPrim,
-        WeightedOneOfPrim)
+        WeightedOneOfAgentSet,
+        WeightedOneOfList,
+        WeightedNOfAgentSetWithRepeats,
+        WeightedNOfListWithRepeats,
+        WeightedNOfAgentSetWithoutRepeats,
+        WeightedNOfListWithoutRepeats)
     } primManager.addPrimitive(prim.name, prim)
   }
 }

--- a/tests.txt
+++ b/tests.txt
@@ -1,29 +1,29 @@
 order-of-a-list-is-preserved-for-strings
   extensions [ rnd ]
   O> set glob1 ["9a" "8b" "7c" "6d" "5e" "4f" "3g" "2h" "1i"]
-  O> set glob2 rnd:weighted-n-of 8 glob1 [ 1.0 ]
+  O> set glob2 rnd:weighted-n-of-list 8 glob1 [ 1.0 ]
   glob2 = sort-by [item 1 ?1 < item 1 ?2] glob2 => true
-  O> set glob2 rnd:weighted-n-of-with-repeats 8 glob1 [ 1.0 ]
+  O> set glob2 rnd:weighted-n-of-list-with-repeats 8 glob1 [ 1.0 ]
   glob2 = sort-by [item 1 ?1 < item 1 ?2] glob2 => true
 
 order-of-a-list-is-preserved-for-ints
   extensions [ rnd ]
   O> set glob1 n-values 100 [?]
-  O> set glob2 rnd:weighted-n-of 50 glob1 [ 1.0 ]
+  O> set glob2 rnd:weighted-n-of-list 50 glob1 [ 1.0 ]
   glob2 = sort glob2 => true
-  O> set glob2 rnd:weighted-n-of-with-repeats 50 glob1 [ 1.0 ]
+  O> set glob2 rnd:weighted-n-of-list-with-repeats 50 glob1 [ 1.0 ]
   glob2 = sort glob2 => true
 
 same-list-returned-if-n-equals-size
   extensions [ rnd ]
   O> set glob1 ["a" "s" "d" "f" "g" "h" "j" "k" "l"]
-  glob1 = rnd:weighted-n-of length glob1 glob1 [ 1.0 ] => true
+  glob1 = rnd:weighted-n-of-list (length glob1) glob1 [ 1.0 ] => true
 
 different-list-returned-if-n-equals-size-with-repeats
   # chance of this failing should be ~2.6E-9
   extensions [ rnd ]
   O> set glob1 ["a" "s" "d" "f" "g" "h" "j" "k" "l"]
-  glob1 = rnd:weighted-n-of-with-repeats length glob1 glob1 [ 1.0 ] => false
+  glob1 = rnd:weighted-n-of-list-with-repeats (length glob1) glob1 [ 1.0 ] => false
 
 same-agentset-returned-if-n-equals-size
   extensions [ rnd ]
@@ -51,19 +51,34 @@ different-arrayagentset-returned-if-n-equals-size-with-repeats
   O> ask n-of 10 turtles [ set color red ]
   sort turtles with [ color = red ] = sort rnd:weighted-n-of-with-repeats 10 turtles with [ color = red ] [ 1.0 ] => false
 
-first-input-cannot-be-negative
+first-input-cannot-be-negative-with-empty-list
   extensions [ rnd ]
-  rnd:weighted-n-of -1 [] [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF can't be negative.
-  rnd:weighted-n-of -1 [1 2 3] [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF can't be negative.
+  rnd:weighted-n-of-list -1 [] [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF-LIST can't be negative.
+
+first-input-cannot-be-negative-with-small-list
+  extensions [ rnd ]
+  rnd:weighted-n-of-list -1 [1 2 3] [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF-LIST can't be negative.
+
+first-input-cannot-be-negative-with-agentset
+  extensions [ rnd ]
   rnd:weighted-n-of -1 turtles [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF can't be negative.
-  rnd:weighted-n-of-with-repeats -1 [] [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF-WITH-REPEATS can't be negative.
-  rnd:weighted-n-of-with-repeats -1 [1 2 3] [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF-WITH-REPEATS can't be negative.
+
+first-input-cannot-be-negative-with-repeats-with-empty-list
+  extensions [ rnd ]
+  rnd:weighted-n-of-list-with-repeats -1 [] [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF-LIST-WITH-REPEATS can't be negative.
+
+first-input-cannot-be-negative-with-repeats-with-small-list
+  extensions [ rnd ]
+  rnd:weighted-n-of-list-with-repeats -1 [1 2 3] [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF-LIST-WITH-REPEATS can't be negative.
+
+first-input-cannot-be-negative-with-repeats-with-agentset
+  extensions [ rnd ]
   rnd:weighted-n-of-with-repeats -1 turtles [ 1.0 ] => ERROR Extension exception: First input to WEIGHTED-N-OF-WITH-REPEATS can't be negative.
 
 requesting-zero-items-from-list-gives-empty-list
   extensions [ rnd ]
-  rnd:weighted-n-of 0 [1 2 3] [ 1.0 ] => []
-  rnd:weighted-n-of-with-repeats 0 [1 2 3] [ 1.0 ] => []
+  rnd:weighted-n-of-list 0 [1 2 3] [ 1.0 ] => []
+  rnd:weighted-n-of-list-with-repeats 0 [1 2 3] [ 1.0 ] => []
 
 requesting-zero-items-from-agentset-gives-empty-agentset
   extensions [ rnd ]
@@ -77,8 +92,8 @@ requesting-zero-items-from-agentset-with-repeats-gives-empty-list
 
 requesting-zero-items-from-empty-list-gives-empty-list
   extensions [ rnd ]
-  rnd:weighted-n-of 0 [] [ 1.0 ] => []
-  rnd:weighted-n-of-with-repeats 0 [] [ 1.0 ] => []
+  rnd:weighted-n-of-list 0 [] [ 1.0 ] => []
+  rnd:weighted-n-of-list-with-repeats 0 [] [ 1.0 ] => []
 
 requesting-zero-items-from-empty-agentset-gives-empty-agentset
   extensions [ rnd ]
@@ -90,8 +105,8 @@ requesting-zero-items-from-empty-agentset-with-repeats-gives-empty-list
 
 requesting-n-from-empty-list-gives-error
   extensions [ rnd ]
-  rnd:weighted-n-of 1 [] [ 1.0 ] => ERROR Extension exception: Requested 1 random item from 0 candidates.
-  rnd:weighted-n-of-with-repeats 1 [] [ 1.0 ] => ERROR Extension exception: Requested 1 random item from 0 candidates.
+  rnd:weighted-n-of-list 1 [] [ 1.0 ] => ERROR Extension exception: Requested 1 random item from 0 candidates.
+  rnd:weighted-n-of-list-with-repeats 1 [] [ 1.0 ] => ERROR Extension exception: Requested 1 random item from 0 candidates.
 
 requesting-n-from-empty-agentset-gives-error
   extensions [ rnd ]
@@ -100,7 +115,7 @@ requesting-n-from-empty-agentset-gives-error
 
 requesting-one-from-empty-list-gives-error
   extensions [ rnd ]
-  rnd:weighted-one-of [] [ 1.0 ] => ERROR Extension exception: Requested 1 random item from 0 candidates.
+  rnd:weighted-one-of-list [] [ 1.0 ] => ERROR Extension exception: Requested 1 random item from 0 candidates.
 
 requesting-one-from-empty-agentset-gives-nobody
   extensions [ rnd ]
@@ -108,11 +123,11 @@ requesting-one-from-empty-agentset-gives-nobody
 
 requesting-more-items-than-in-list-gives-error
   extensions [ rnd ]
-  rnd:weighted-n-of 5 [1 2 3] [ 1.0 ] => ERROR Extension exception: Requested 5 random items from 3 candidates.
+  rnd:weighted-n-of-list 5 [1 2 3] [ 1.0 ] => ERROR Extension exception: Requested 5 random items from 3 candidates.
 
 requesting-more-items-than-in-list-with-repeats-works
   extensions [ rnd ]
-  length rnd:weighted-n-of-with-repeats 5 [1 2 3] [ 1.0 ] => 5
+  length rnd:weighted-n-of-list-with-repeats 5 [1 2 3] [ 1.0 ] => 5
 
 requesting-more-items-than-in-agentset-gives-error
   extensions [ rnd ]
@@ -126,122 +141,122 @@ requesting-more-items-than-in-agentset-with-repeats-works
 
 requesting-one-of-list-with-all-zeros-weights
   extensions [ rnd ]
-  rnd:weighted-one-of [1 1 1] [ 0.0 ] => 1
+  rnd:weighted-one-of-list [1 1 1] [ 0.0 ] => 1
 
 requesting-more-items-than-items-with-positive-weights-in-list
   extensions [ rnd ]
-  sort rnd:weighted-n-of 3 [0 0 0 1 1] [ ? ] => [0 1 1]
-  rnd:weighted-n-of-with-repeats 3 [0 0 0 1 1] [ ? ] => [1 1 1]
+  sort rnd:weighted-n-of-list 3 [0 0 0 1 1] [ ? ] => [0 1 1]
+  rnd:weighted-n-of-list-with-repeats 3 [0 0 0 1 1] [ ? ] => [1 1 1]
 
 requesting-more-items-than-items-with-positive-weights-in-agentset
   extensions [ rnd ]
   O> crt 5 [ set tvar 0.0 ]
   O> ask n-of 2 turtles [ set tvar 1.0 ]
-  sort [ tvar ] of rnd:weighted-n-of 3 turtles [ [ tvar ] of ? ] => [0 1 1]
-  map [ [ tvar ] of ? ] rnd:weighted-n-of-with-repeats 3 turtles [ [ tvar ] of ? ] => [1 1 1]
+  sort [ tvar ] of rnd:weighted-n-of 3 turtles [ tvar ] => [0 1 1]
+  map [ [ tvar ] of ? ] rnd:weighted-n-of-with-repeats 3 turtles [ tvar ] => [1 1 1]
 
 negative-weight-gives-error-with-list
   extensions [ rnd ]
   O> set glob1 [1 1 -1 1 1]
-  rnd:weighted-n-of 3 [0 1 2 3 4] [ item ? glob1 ] => ERROR Extension exception: Got -1.0 as a weight but all weights must be >= 0.0.
-  rnd:weighted-n-of-with-repeats 3 [0 1 2 3 4] [ item ? glob1 ] => ERROR Extension exception: Got -1.0 as a weight but all weights must be >= 0.0.
+  rnd:weighted-n-of-list 3 [0 1 2 3 4] [ item ? glob1 ] => ERROR Extension exception: Got -1.0 as a weight but all weights must be >= 0.0.
+  rnd:weighted-n-of-list-with-repeats 3 [0 1 2 3 4] [ item ? glob1 ] => ERROR Extension exception: Got -1.0 as a weight but all weights must be >= 0.0.
 
 negative-weight-gives-error-with-agentset
   extensions [ rnd ]
   O> crt 5 [ set tvar 1 ]
   O> ask n-of 1 turtles [ set tvar -1 ]
-  rnd:weighted-n-of 3 turtles [ [ tvar ] of ? ] => ERROR Extension exception: Got -1.0 as a weight but all weights must be >= 0.0.
-  rnd:weighted-n-of-with-repeats 3 turtles [ [ tvar ] of ? ] => ERROR Extension exception: Got -1.0 as a weight but all weights must be >= 0.0.
+  rnd:weighted-n-of 3 turtles [ tvar ] => ERROR Extension exception: Got -1.0 as a weight but all weights must be >= 0.0.
+  rnd:weighted-n-of-with-repeats 3 turtles [ tvar ] => ERROR Extension exception: Got -1.0 as a weight but all weights must be >= 0.0.
 
 non-numeric-weight-gives-error-with-list
   extensions [ rnd ]
   O> set glob1 [1 1 "x" 1 1]
-  rnd:weighted-n-of 3 [0 1 2 3 4] [ item ? glob1 ] => ERROR Extension exception: Got x as a weight but all weights must be numbers.
-  rnd:weighted-n-of-with-repeats 3 [0 1 2 3 4] [ item ? glob1 ] => ERROR Extension exception: Got x as a weight but all weights must be numbers.
+  rnd:weighted-n-of-list 3 [0 1 2 3 4] [ item ? glob1 ] => ERROR Extension exception: Got x as a weight but all weights must be numbers.
+  rnd:weighted-n-of-list-with-repeats 3 [0 1 2 3 4] [ item ? glob1 ] => ERROR Extension exception: Got x as a weight but all weights must be numbers.
 
 non-numeric-weight-gives-error-with-agentset
   extensions [ rnd ]
   O> crt 5 [ set tvar 1 ]
   O> ask n-of 1 turtles [ set tvar "x" ]
-  rnd:weighted-n-of 3 turtles [ [ tvar ] of ? ] => ERROR Extension exception: Got x as a weight but all weights must be numbers.
-  rnd:weighted-n-of-with-repeats 3 turtles [ [ tvar ] of ? ] => ERROR Extension exception: Got x as a weight but all weights must be numbers.
+  rnd:weighted-n-of 3 turtles [ tvar ] => ERROR Extension exception: Got x as a weight but all weights must be numbers.
+  rnd:weighted-n-of-with-repeats 3 turtles [ tvar ] => ERROR Extension exception: Got x as a weight but all weights must be numbers.
 
 only-positive-weights-get-selected-from-list
   extensions [ rnd ]
   O> set glob1 [1 0 1 0 1]
-  remove-duplicates n-values 1000 [ rnd:weighted-n-of 3 [0 1 2 3 4] [ item ? glob1 ] ] => [[0 2 4]]
-  remove-duplicates rnd:weighted-n-of-with-repeats 1000 [0 1 2 3 4] [ item ? glob1 ] => [0 2 4]
+  remove-duplicates n-values 1000 [ rnd:weighted-n-of-list 3 [0 1 2 3 4] [ item ? glob1 ] ] => [[0 2 4]]
+  remove-duplicates rnd:weighted-n-of-list-with-repeats 1000 [0 1 2 3 4] [ item ? glob1 ] => [0 2 4]
 
 only-positive-weights-get-selected-from-agentset
   extensions [ rnd ]
   O> crt 5 [ set tvar 0 ]
   O> set glob1 n-of 3 turtles
   O> ask glob1 [ set tvar 1 ]
-  turtle-set n-values 1000 [ rnd:weighted-n-of 3 turtles [ [ tvar ] of ? ] ] = glob1 => true
-  turtle-set rnd:weighted-n-of-with-repeats 1000 turtles [ [ tvar ] of ? ] = glob1 => true
+  turtle-set n-values 1000 [ rnd:weighted-n-of 3 turtles [ tvar ] ] = glob1 => true
+  turtle-set rnd:weighted-n-of-with-repeats 1000 turtles [ tvar ] = glob1 => true
 
 too-many-inputs-for-task-should-give-error
   extensions [ rnd ]
-  rnd:weighted-n-of 3 [0 1 2 3 4] [ ?1 + ?2 ] => ERROR Extension exception: Task expected only 1 input but got 2.
-  rnd:weighted-n-of 3 [0 1 2 3 4] [ ?1 + ?2 + ?3] => ERROR Extension exception: Task expected only 1 input but got 3.
-  rnd:weighted-n-of-with-repeats 3 [0 1 2 3 4] [ ?1 + ?2 ] => ERROR Extension exception: Task expected only 1 input but got 2.
-  rnd:weighted-n-of-with-repeats 3 [0 1 2 3 4] [ ?1 + ?2 + ?3] => ERROR Extension exception: Task expected only 1 input but got 3.
+  rnd:weighted-n-of-list 3 [0 1 2 3 4] [ ?1 + ?2 ] => ERROR Extension exception: Task expected only 1 input but got 2.
+  rnd:weighted-n-of-list 3 [0 1 2 3 4] [ ?1 + ?2 + ?3] => ERROR Extension exception: Task expected only 1 input but got 3.
+  rnd:weighted-n-of-list-with-repeats 3 [0 1 2 3 4] [ ?1 + ?2 ] => ERROR Extension exception: Task expected only 1 input but got 2.
+  rnd:weighted-n-of-list-with-repeats 3 [0 1 2 3 4] [ ?1 + ?2 + ?3] => ERROR Extension exception: Task expected only 1 input but got 3.
 
 two-for-one-ratio-roughly-respected-for-weighted-one-of
   extensions [ rnd ]
-  O> set glob1 n-values 1E5 [ rnd:weighted-one-of [2 1] [ ? ] ]
+  O> set glob1 n-values 1E5 [ rnd:weighted-one-of-list [2 1] [ ? ] ]
   O> set glob2 (length filter [ ? = 2 ] glob1) / (length filter [ ? = 1 ] glob1)
   precision glob2 1 => 2
 
 two-for-one-ratio-roughly-respected-for-weighted-n-of
   extensions [ rnd ]
-  O> set glob1 n-values 1E5 [ first rnd:weighted-n-of 1 [2 1] [ ? ] ]
+  O> set glob1 n-values 1E5 [ first rnd:weighted-n-of-list 1 [2 1] [ ? ] ]
   O> set glob2 (length filter [ ? = 2 ] glob1) / (length filter [ ? = 1 ] glob1)
   precision glob2 1 => 2
 
 two-for-one-ratio-roughly-respected-for-weighted-n-of-with-repeats
   extensions [ rnd ]
-  O> set glob1 rnd:weighted-n-of-with-repeats 1E5 [2 1] [ ? ]
+  O> set glob1 rnd:weighted-n-of-list-with-repeats 1E5 [2 1] [ ? ]
   O> set glob2 (length filter [ ? = 2 ] glob1) / (length filter [ ? = 1 ] glob1)
   precision glob2 1 => 2
 
 relative-order-of-weights-respected-in-sampling-with-weighted-n-of
   extensions [ rnd ]
-  O> set glob1 n-values 1E5 [ first rnd:weighted-n-of 1 (n-values 10 [ ? ]) [ ? ] ]
+  O> set glob1 n-values 1E5 [ first rnd:weighted-n-of-list 1 (n-values 10 [ ? ]) [ ? ] ]
   O> set glob2 n-values 10 [ 0 ]
   O> foreach glob1 [ set glob2 replace-item ? glob2 (item ? glob2 + 1) ]
   glob2 = sort glob2 => true
 
 relative-order-of-weights-respected-in-sampling-with-weighted-n-of-with-repeats
   extensions [ rnd ]
-  O> set glob1 rnd:weighted-n-of-with-repeats 1E5 (n-values 10 [ ? ]) [ ? ]
+  O> set glob1 rnd:weighted-n-of-list-with-repeats 1E5 (n-values 10 [ ? ]) [ ? ]
   O> set glob2 n-values 10 [ 0 ]
   O> foreach glob1 [ set glob2 replace-item ? glob2 (item ? glob2 + 1) ]
   glob2 = sort glob2 => true
 
 relative-order-of-weights-respected-in-sampling-with-weighted-one-of
   extensions [ rnd ]
-  O> set glob1 n-values 1E5 [ rnd:weighted-one-of (n-values 10 [ ? ]) [ ? ] ]
+  O> set glob1 n-values 1E5 [ rnd:weighted-one-of-list (n-values 10 [ ? ]) [ ? ] ]
   O> set glob2 n-values 10 [ 0 ]
   O> foreach glob1 [ set glob2 replace-item ? glob2 (item ? glob2 + 1) ]
   glob2 = sort glob2 => true
 
 acceptable-performance-when-one-item-outweights-the-others
   extensions [ rnd ]
-  member? 0 rnd:weighted-n-of 9 (n-values 10 [ ? ]) [ ifelse-value (? = 0) [ 1E10 ] [ 1E-10 ] ] => true
-  member? 1 rnd:weighted-n-of-with-repeats 9 (n-values 10 [ ? ]) [ ifelse-value (? = 0) [ 1E10 ] [ 1E-10 ] ] => false
+  member? 0 rnd:weighted-n-of-list 9 (n-values 10 [ ? ]) [ ifelse-value (? = 0) [ 1E10 ] [ 1E-10 ] ] => true
+  member? 1 rnd:weighted-n-of-list-with-repeats 9 (n-values 10 [ ? ]) [ ifelse-value (? = 0) [ 1E10 ] [ 1E-10 ] ] => false
 
 acceptable-performance-selecting-most-of-large-list
   extensions [ rnd ]
   O> set glob1 n-values 1E5 [ ? ]
   O> set glob2 floor (length glob1 * 0.8)
-  length rnd:weighted-n-of glob2 glob1 [ 1.0 ] = glob2 => true
+  length rnd:weighted-n-of-list glob2 glob1 [ 1.0 ] = glob2 => true
 
 weighted-n-of-always-returns-n-items
   extensions [ rnd ]
   O> set glob1 n-values 100 [ ? ]
-  glob1 = map [ length rnd:weighted-n-of ? glob1 [ item ? glob1 ]] glob1 => true
-  glob1 = map [ length rnd:weighted-n-of-with-repeats ? glob1 [ item ? glob1 ]] glob1 => true
+  glob1 = map [ length rnd:weighted-n-of-list ? glob1 [ item ? glob1 ]] glob1 => true
+  glob1 = map [ length rnd:weighted-n-of-list-with-repeats ? glob1 [ item ? glob1 ]] glob1 => true
 
 return-different-agentset-even-if-requesting-all-agents
   extensions [ rnd ]


### PR DESCRIPTION
To address #5, we now provide separate sets of primitives for selecting agents out of an agentset and items out of a list. This means that the old awkward syntax for selecting an agent:
```
rnd:weighted-one-of turtles [ [ size ] of ? ]
```
...is now replaced by the much nicer:
```
rnd:weighted-one-of turtles [ size ]
```
To select an item from a list, you now need to use one of the new `-list` primitives:
```
rnd:weighted-one-of-list [ 1 2 3 4 5 ] [ ? ]
```
This breaks backward compatibility, but seems worth it since multiple people have been stumped by the old syntax.

Here is the new set of primitives:

|                             | From an AgentSet                 | From a List                           |
|-----------------------------|----------------------------------|---------------------------------------|
| One item                    | `rnd:weighted-one-of`            | `rnd:weighted-one-of-list`            |
| Many items, without repeats | `rnd:weighted-n-of`              | `rnd:weighted-n-of-list`              |
| Many items, with repeats    | `rnd:weighted-n-of-with-repeats` | `rnd:weighted-n-of-list-with-repeats` |

I would appreciate if anyone has a moment a moment to [look at the new documentation](https://github.com/NetLogo/Rnd-Extension/blob/issue-5/README.md) and tell me what they think. (@BruceEdmonds, @jbadham, amongst others, you have both used the extension and I'd value your opinions.)

Two questions that are still (somewhat) open:

- Are these the right names for the new primitives?

  I'm assuming the agentset case will be by far the most frequent, so it makes sense to keep the shorter names for it, but maybe someone can come up with better names for the `-list` primitives (or a new scheme altogether!)

- Should "with repeats" be a parameter instead of a separate primitive?

  I think that "_without_ repeats" is the most common case, but I'm not entirely sure. If it was a parameter, you'd have to provide it all the time, which could be annoying. The two primitives also have different return types: list for "with repeats", agentset for "without repeats". Keeping them separate allows NetLogo to detect misuse at compile time instead of runtime.